### PR TITLE
Moar Plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,32 @@
 'use strict';
-module.exports = require('./lib/server')();
+const server = require('./lib/server');
+
+/**
+ * User Plugin. A plugin that the user wishes for the Screwdriver API to register and use
+ * @typedef {Object} UserPlugin
+ * @property {Object} register  A HapiJS plugin `register` function. It honors the interface
+ *                              that all HapiJS plugins implement.
+ * @property {Object} options  Additional options to load with the plugin.
+ */
+
+/**
+ * Start the Screwdriver API.
+ * Optionally, it can be started up with an additional set of plugins
+ * @method
+ * @param  {Array.<UserPlugin>}   [userPlugins]  Optional. An array of additional plugins to start
+ *                                               up the server with.
+ * @param  {Function}             callback       Function to invoke when server is started
+ * @return {http.Server}                         A listener: NodeJS http.Server object
+ */
+module.exports = (userPlugins, callback) => {
+    let cb = callback;
+    let additionalPlugins = userPlugins;
+
+    if (typeof userPlugins === 'function') {
+        // userPlugins ommitted
+        additionalPlugins = [];
+        cb = userPlugins;
+    }
+
+    return server(additionalPlugins, cb);
+};

--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -1,7 +1,13 @@
 'use strict';
 const async = require('async');
 
-module.exports = (server, callback) => {
+/**
+ * Register the default Screwdriver API plugins
+ * @method registerDefaultPlugins
+ * @param  {Object}               server   HapiJS server object
+ * @param  {Function}             callback Function to indicate when completed with registration
+ */
+function registerDefaultPlugins(server, callback) {
     const plugins = [
         'inert',
         'vision',
@@ -18,4 +24,45 @@ module.exports = (server, callback) => {
             }
         }, next);
     }, callback);
+}
+
+/**
+ * User Plugin. A plugin that the user wishes for the Screwdriver API to register and use
+ * @typedef {Object} UserPlugin
+ * @property {Object} register  A HapiJS plugin `register` function. It honors the interface
+ *                              that all HapiJS plugins implement.
+ * @property {Object} options  Additional options to load with the plugin.
+ */
+
+/**
+ * Register any user-requested plugins
+ * @method registerAdditionalPlugins
+ * @param  {Objec}                  server    HapiJS server object
+ * @param  {Array.<UserPlugin>}     plugins   An array of plugins to register
+ * @param  {Function}               callback  Function to invoke when completed
+ */
+function registerAdditionalPlugins(server, plugins, callback) {
+    server.register(plugins, {
+        routes: {
+            prefix: '/v3'
+        }
+    }, callback);
+}
+
+/**
+ * Registers the default set of plugins and any passed in plugins
+ * @method
+ * @param  {Object}               server            HapiJS server object
+ * @param  {Array.<UserPlugin>}   additionalPlugins An array of user-requested plugins to register
+ *                                                  with the Screwdriver API
+ * @param  {Function}             callback          Function to invoke when plugin registration is completed
+ */
+module.exports = (server, additionalPlugins, callback) => {
+    registerDefaultPlugins(server, (err) => {
+        if (err) {
+            return callback(err);
+        }
+
+        return registerAdditionalPlugins(server, additionalPlugins, callback);
+    });
 };

--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -37,7 +37,7 @@ function registerDefaultPlugins(server, callback) {
 /**
  * Register any user-requested plugins
  * @method registerAdditionalPlugins
- * @param  {Objec}                  server    HapiJS server object
+ * @param  {Object}                 server    HapiJS server object
  * @param  {Array.<UserPlugin>}     plugins   An array of plugins to register
  * @param  {Function}               callback  Function to invoke when completed
  */
@@ -50,7 +50,7 @@ function registerAdditionalPlugins(server, plugins, callback) {
 }
 
 /**
- * Registers the default set of plugins and any passed in plugins
+ * Register the default set of plugins and any passed in plugins
  * @method
  * @param  {Object}               server            HapiJS server object
  * @param  {Array.<UserPlugin>}   additionalPlugins An array of user-requested plugins to register

--- a/lib/server.js
+++ b/lib/server.js
@@ -18,12 +18,22 @@ function handleError(error, callback) {
 }
 
 /**
+ * User Plugin. A plugin that the user wishes for the Screwdriver API to register and use
+ * @typedef {Object} UserPlugin
+ * @property {Object} register  A HapiJS plugin `register` function. It honors the interface
+ *                              that all HapiJS plugins implement.
+ * @property {Object} options  Additional options to load with the plugin.
+ */
+
+/**
  * Configures & starts up a HapiJS server
  * @method
- * @param  {Function} [callback] Callback to invoke when server has started.
- * @return {http.Server}         A listener: NodeJS http.Server object
+ * @param  {Array.<UserPlugin>}  plugins    An array of user-requested plugins to register
+ *                                          with the Screwdriver API
+ * @param  {Function}            [callback] Callback to invoke when server has started.
+ * @return {http.Server}                    A listener: NodeJS http.Server object
  */
-module.exports = (callback) => {
+module.exports = (plugins, callback) => {
     const connectionOptions = {
         listener,
         autoListen: false
@@ -41,7 +51,7 @@ module.exports = (callback) => {
     server.connection(connectionOptions);
 
     // Register plugins
-    registrationMan(server, (err) => {
+    registrationMan(server, plugins, (err) => {
         if (err) {
             return handleError(err, callback);
         }

--- a/localserver.js
+++ b/localserver.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+'use strict';
+
+module.exports = require('./index')(() => {
+    console.log('Server started');  // eslint-disable-line no-console
+});

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "screwdriver-api",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "API module for the Screwdriver CD service",
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
     "test": "jenkins-mocha --recursive",
-    "start": "PORT=8666 node index.js",
+    "start": "PORT=8666 node localserver.js",
     "functional": "cucumber-js --format=pretty --format=json:${TEST_DIR}/cucumber_output.json; cat ${TEST_DIR}/cucumber_output.json | cucumber-junit > ${TEST_DIR}/func_test_results.xml"
   },
   "repository": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,71 @@
+/* eslint-disable global-require */
+'use strict';
+const chai = require('chai');
+const Assert = chai.assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(chai.assert, { prefix: '' });
+describe('Index Unit Test Case', () => {
+    let main;
+    let mocks;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        mocks = {
+            listener: sinon.stub(),
+            server: sinon.stub()
+        };
+        mockery.registerMock('./lib/server', mocks.server);
+
+        main = require('../index');
+    });
+
+    afterEach(() => {
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    it('optionally accepts no additional plugins', (done) => {
+        mocks.server.yieldsAsync(null);
+        mocks.server.returns(mocks.listener);
+
+        const result = main((err) => {
+            Assert.isNull(err);
+            Assert.calledWith(mocks.server, []);
+            Assert.deepEqual(result, mocks.listener);
+            done();
+        });
+    });
+
+    it('calls the server with the appropriate args', (done) => {
+        mocks.server.yieldsAsync(null);
+        mocks.server.returns(mocks.listener);
+
+        const result = main(['abc'], (err) => {
+            Assert.isNull(err);
+            Assert.calledWith(mocks.server, ['abc']);
+            Assert.deepEqual(result, mocks.listener);
+            done();
+        });
+    });
+
+    it('returns an error when starting the server', (done) => {
+        mocks.server.yieldsAsync(new Error('someErrorMessage'));
+
+        main([], (err) => {
+            Assert.strictEqual(err.message, 'someErrorMessage');
+            done();
+        });
+    });
+});

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -40,7 +40,7 @@ describe('server case', () => {
         });
 
         it('injects the status', (done) => {
-            hapiEngine((error, server) => {
+            hapiEngine([], (error, server) => {
                 Assert.notOk(error);
                 server.inject({
                     method: 'GET',
@@ -52,10 +52,30 @@ describe('server case', () => {
             });
         });
 
+        it('registers an additional plugin', (done) => {
+            hapiEngine([
+                {
+                    // eslint-disable-next-line global-require
+                    register: require('../testData/dummyPlugin'),
+                    options: {}
+                }
+            ], (err, server) => {
+                Assert.notOk(err);
+                server.inject({
+                    method: 'GET',
+                    url: '/v3/dummy'
+                }, (response) => {
+                    Assert.equal(response.statusCode, 200);
+                    Assert.equal(response.payload, 'dummy');
+                    done();
+                });
+            });
+        });
+
         it('does it with a different port', (done) => {
             processEnvMock.PORT = 12347;
 
-            hapiEngine((error, server) => {
+            hapiEngine([], (error, server) => {
                 Assert.notOk(error);
                 server.inject({
                     method: 'GET',
@@ -82,7 +102,7 @@ describe('server case', () => {
 
         it('callsback errors with register plugins', (done) => {
             registrationManMock.yieldsAsync('registrationMan fail');
-            hapiEngine((error) => {
+            hapiEngine([], (error) => {
                 Assert.strictEqual('registrationMan fail', error);
                 done();
             });

--- a/test/testData/dummyPlugin.js
+++ b/test/testData/dummyPlugin.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports.register = (server, options, next) => {
+    server.route({
+        method: 'GET',
+        path: '/dummy',
+        handler: (request, reply) => {
+            reply('dummy');
+        }
+    });
+
+    next();
+};
+
+module.exports.register.attributes = {
+    name: 'dummyPlugin',
+    version: '1.0.0'
+};


### PR DESCRIPTION
This PR allows the API to load an extra set of plugins in the HapiJS server, as well as any associated `options`.

