### PR TITLE
Register resource plugins with configurable datastore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Screwdriver Screwdriver API
+# Screwdriver API
 [![Version][npm-image]][npm-url] ![Downloads][downloads-image] [![Build Status][wercker-image]][wercker-url] [![Open Issues][issues-image]][issues-url] [![Dependency Status][daviddm-image]][daviddm-url] ![License][license-image]
 
 > API module for the Screwdriver CD service
@@ -14,17 +14,34 @@ const API = require('screwdriver-api');
 const Datastore = require('screwdriver-datastore-dynamodb');
 
 const server = new API({
-    datastore: new Datastore({
-        field: '???'
-    }),
+    datastore: new Datastore(),
     port: 8666
+}, (error, server) {
+    if (error) {
+        return console.error(error);
+    }
+    console.log('Server running at ', server.info.uri);
 });
 ```
 
 ## Testing
 
+### Unit Tests
+
 ```bash
 npm test
+```
+
+### Functional tests
+
+First start the demo server:
+```bash
+npm start
+```
+
+Then run the cucumber tests:
+```bash
+INSTANCE="http://localhost:8666" npm run functional
 ```
 
 ## License

--- a/bin/server
+++ b/bin/server
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+'use strict';
+
+const winston = require('winston');
+const inMemoryDatastore = {
+    scanAll: (next) => {
+        next(new Error('Scan All Not Implemented'));
+    },
+    get: (id, next) => {
+        next(new Error(`Get ${id} Not Implemented`));
+    }
+};
+
+require('../')({
+    port: process.env.PORT,
+    datastore: inMemoryDatastore
+}, (err, server) => {
+    if (err) {
+        winston.error(err);
+
+        return process.exit(1);
+    }
+
+    return winston.info('Server running at %s', server.info.uri);
+});

--- a/features/step_definitions/server.js
+++ b/features/step_definitions/server.js
@@ -1,15 +1,16 @@
 'use strict';
+
 const request = require('request');
 const Assert = require('chai').assert;
 
-module.exports = () => {
+module.exports = function server() {
     this.Given(/^a running hapi server$/, (callback) => {
         this.instance = process.env.INSTANCE;
         callback(null);
     });
 
     this.When(/^I access a status endpoint$/, (callback) => {
-        request.get(`${this.instance}, /v3/status`, (err, result) => {
+        request.get(`${this.instance}/v3/status`, (err, result) => {
             this.body = result ? result.body : null;
             callback(err);
         });

--- a/index.js
+++ b/index.js
@@ -1,2 +1,4 @@
 'use strict';
-module.exports = require('./lib/server')();
+const server = require('./lib/server');
+
+module.exports = (config, callback) => server(config, callback);

--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -1,16 +1,23 @@
 'use strict';
 const async = require('async');
 
-module.exports = (server, callback) => {
+/**
+ * Register the default plugins
+ * @method registerDefaultPlugins
+ * @param  {Object}   server        Hapi server object
+ * @param  {Function} callback
+ */
+function registerDefaultPlugins(server, callback) {
     const plugins = [
         'inert',
         'vision',
         '../plugins/status',
         '../plugins/logging',
         '../plugins/swagger'
-    ].map((plugin) => require(plugin)); // eslint-disable-line global-require
+    /* eslint-disable global-require */
+    ].map((plugin) => require(plugin));
+    /* eslint-enable global-require */
 
-    // TODO: possible performance boost on server startup by only calling register once
     async.eachSeries(plugins, (plugin, next) => {
         server.register(plugin, {
             routes: {
@@ -18,4 +25,40 @@ module.exports = (server, callback) => {
             }
         }, next);
     }, callback);
+}
+
+/**
+ * Register resource plugins
+ * @method registerResourcePlugins
+ * @param  {Object}   server            Hapi server object
+ * @param  {Object}   config            Configuration object for resource plugin
+ * @param  {String}   config.datastore  Name of datastore module
+ * @param  {Function} callback
+ */
+function registerResourcePlugins(server, config, callback) {
+    const plugins = [
+        'screwdriver-plugin-builds'
+    /* eslint-disable global-require */
+    ].map((plugin) => require(plugin));
+    /* eslint-enable global-require */
+
+    async.eachSeries(plugins, (plugin, next) => {
+        server.register({
+            register: plugin,
+            options: {
+                datastore: config.datastore
+            }
+        }, {
+            routes: {
+                prefix: '/v3'
+            }
+        }, next);
+    }, callback);
+}
+
+module.exports = (server, config, callback) => {
+    async.series([
+        async.apply(registerDefaultPlugins, server),
+        async.apply(registerResourcePlugins, server, config)
+    ], callback);
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -4,34 +4,20 @@ const Hapi = require('hapi');
 const registrationMan = require('./registerPlugins');
 
 /**
- * Determines whether to handle errors asynchronously, or throw the error instead
- * @method handleError
- * @param  {Error}     error       The specific error to handle
- * @param  {Function}  [callback]  Callback to send error with, if provided
- */
-function handleError(error, callback) {
-    if (callback) {
-        return callback(error);
-    }
-
-    throw error;
-}
-
-/**
  * Configures & starts up a HapiJS server
  * @method
- * @param  {Function} [callback] Callback to invoke when server has started.
- * @return {http.Server}         A listener: NodeJS http.Server object
+ * @param  {Object}      config
+ * @param  {Integer}     [config.port]    Port number to listen to
+ * @param  {Datastore}   config.datastore Datastore to use for resources
+ * @param  {Function}    callback         Callback to invoke when server has started.
+ * @return {http.Server}                  A listener: NodeJS http.Server object
  */
-module.exports = (callback) => {
-    const connectionOptions = {
-        listener,
-        autoListen: false
-    };
+module.exports = (config, callback) => {
+    const connectionOptions = { listener };
 
-    if (process.env.PORT) {
-        delete connectionOptions.autoListen;
-        connectionOptions.port = process.env.PORT;
+    // Optionally specify a port
+    if (config.port) {
+        connectionOptions.port = config.port;
     }
 
     // Create a server with a host and port
@@ -41,31 +27,13 @@ module.exports = (callback) => {
     server.connection(connectionOptions);
 
     // Register plugins
-    registrationMan(server, (err) => {
+    registrationMan(server, config, (err) => {
         if (err) {
-            return handleError(err, callback);
+            return callback(err);
         }
 
-        // Server should print out URI when it starts listening
-        // (NOTE: this may not happen at server.start)
-        server.listener.on('listening', () => {
-            /* eslint-disable no-console */
-            console.log('Server running at:', server.info.uri);
-            /* eslint-enable no-console */
-        });
-
         // Start the server
-        server.start((error) => {
-            if (error) {
-                return handleError(error, callback);
-            }
-
-            if (callback) {
-                return callback(error, server);
-            }
-
-            return 0;
-        });
+        server.start((error) => { callback(error, server); });
 
         return 0;
     });

--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
   "name": "screwdriver-api",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "API module for the Screwdriver CD service",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint .",
+    "pretest": "eslint .",
     "test": "jenkins-mocha --recursive",
-    "start": "PORT=8666 node index.js",
-    "functional": "cucumber-js --format=pretty --format=json:${TEST_DIR}/cucumber_output.json; cat ${TEST_DIR}/cucumber_output.json | cucumber-junit > ${TEST_DIR}/func_test_results.xml"
+    "start": "PORT=8666 node bin/server",
+    "functional": "cucumber-js --format=pretty --format=json:${TEST_DIR:=./artifacts}/cucumber_output.json; cat ${TEST_DIR:=./artifacts}/cucumber_output.json | cucumber-junit > ${TEST_DIR:=./artifacts}/func_test_results.xml"
+  },
+  "bin": {
+    "screwdriver-api": "./bin/server"
   },
   "repository": {
     "type": "git",
@@ -39,7 +42,8 @@
     "hapi-swagger": "^5.1.0",
     "inert": "^3.2.1",
     "screwdriver-plugin-builds": "^1.0.1",
-    "vision": "^4.1.0"
+    "vision": "^4.1.0",
+    "winston": "^2.2.0"
   },
   "devDependencies": {
     "chai": "~3.5.0",

--- a/test/lib/registerPlugins.test.js
+++ b/test/lib/registerPlugins.test.js
@@ -1,0 +1,99 @@
+'use strict';
+const Assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(Assert, { prefix: '' });
+
+describe('Register Unit Test Case', () => {
+    const expectedPlugins = [
+        'inert',
+        'vision',
+        '../plugins/status',
+        '../plugins/logging',
+        '../plugins/swagger'
+    ];
+    const resourcePlugins = [
+        'screwdriver-plugin-builds'
+    ];
+    const pluginLength = expectedPlugins.length + resourcePlugins.length;
+    const mocks = {};
+    const config = {
+        datastore: 'screwdriver-datastore-test'
+    };
+    let main;
+    let serverMock;
+
+    before(() => {
+        mockery.enable({
+            warnOnUnregistered: false,
+            useCleanCache: true
+        });
+    });
+
+    beforeEach(() => {
+        serverMock = {
+            register: sinon.stub()
+        };
+
+        expectedPlugins.forEach((plugin) => {
+            mocks[plugin] = sinon.stub();
+            mockery.registerMock(plugin, mocks[plugin]);
+        });
+
+        resourcePlugins.forEach((plugin) => {
+            mocks[plugin] = sinon.stub();
+            mockery.registerMock(plugin, mocks[plugin]);
+        });
+        /* eslint-disable global-require */
+        main = require('../../lib/registerPlugins');
+        /* eslint-enable global-require */
+    });
+
+    afterEach(() => {
+        mockery.deregisterAll();
+        mockery.resetCache();
+        main = null;
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    it('registered all the default plugins', (done) => {
+        serverMock.register.callsArgAsync(2);
+
+        main(serverMock, config, () => {
+            Assert.equal(serverMock.register.callCount, pluginLength);
+            expectedPlugins.forEach((plugin) => {
+                Assert.calledWith(serverMock.register, mocks[plugin], {
+                    routes: {
+                        prefix: '/v3'
+                    }
+                });
+            });
+            done();
+        });
+    });
+
+    it('registered resource plugins', (done) => {
+        serverMock.register.callsArgAsync(2);
+
+        main(serverMock, config, () => {
+            Assert.equal(serverMock.register.callCount, pluginLength);
+
+            resourcePlugins.forEach((plugin) => {
+                Assert.calledWith(serverMock.register, {
+                    register: mocks[plugin],
+                    options: config
+                }, {
+                    routes: {
+                        prefix: '/v3'
+                    }
+                });
+            });
+
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Allow it to take in a config object that looks like:
```
config: {
    datastore: screwdriver-datastore-dynamo
}
```

And register the builds plugin with the configured datastore. 

(will squash after comments)