### PR TITLE
Register jobs plugin

### DIFF
--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -38,6 +38,7 @@ function registerDefaultPlugins(server, callback) {
 function registerResourcePlugins(server, config, callback) {
     const plugins = [
         'screwdriver-plugin-builds',
+        'screwdriver-plugin-jobs',
         'screwdriver-plugin-pipelines'
     /* eslint-disable global-require */
     ].map((plugin) => require(plugin));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-api",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "API module for the Screwdriver CD service",
   "main": "index.js",
   "scripts": {
@@ -42,7 +42,8 @@
     "hapi-swagger": "^5.1.0",
     "inert": "^3.2.1",
     "screwdriver-plugin-builds": "^1.0.1",
-    "screwdriver-plugin-pipelines": "0.0.2",
+    "screwdriver-plugin-jobs": "^1.0.0",
+    "screwdriver-plugin-pipelines": "^1.0.0",
     "vision": "^4.1.0",
     "winston": "^2.2.0"
   },

--- a/test/lib/registerPlugins.test.js
+++ b/test/lib/registerPlugins.test.js
@@ -15,6 +15,7 @@ describe('Register Unit Test Case', () => {
     ];
     const resourcePlugins = [
         'screwdriver-plugin-builds',
+        'screwdriver-plugin-jobs',
         'screwdriver-plugin-pipelines'
     ];
     const pluginLength = expectedPlugins.length + resourcePlugins.length;


### PR DESCRIPTION
Register the jobs plugin. 
Bump version so that we don't need to pin it in api-aws