### PR TITLE
Add screwdriver-plugin-login

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,39 @@ const server = new API({
 });
 ```
 
+It's also possible to override the config value passed to a resource plugin that is registered.
+The resource plugins being registered are:
+
+1. screwdriver-plugin-login
+2. screwdriver-plugin-builds
+3. screwdriver-plugin-jobs
+4. screwdriver-plugin-pipelines
+5. screwdriver-plugin-platforms
+
+To override a config value specify it in the config passed to screwdriver-api
+```js
+const API = require('screwdriver-api');
+const Datastore = require('screwdriver-datastore-dynamodb');
+
+const server = new API({
+    datastore: new Datastore(),
+    'screwdriver-plugin-login': {
+        login1: 'value1',
+        login2: 'value2'
+        datastore: new Datastore()
+    }
+    port: 8666
+}, (error, server) {
+    if (error) {
+        return console.error(error);
+    }
+    console.log('Server running at ', server.info.uri);
+});
+```
+
+When registering plugin `screwdriver-plugin-login` the specified config object will
+be passed.
+
 ## Testing
 
 ### Unit Tests

--- a/bin/server
+++ b/bin/server
@@ -4,12 +4,26 @@
 const winston = require('winston');
 const path = require('path');
 const inMemoryDatastore = require('screwdriver-datastore-imdb');
+const fs = require('fs');
+
+const jwtPrivateKey = process.env.SECRET_JWT_PRIVATE_KEY;
+const oauthClientId = process.env.SECRET_OAUTH_CLIENT_ID;
+const oauthClientSecret = process.env.SECRET_OAUTH_CLIENT_SECRET;
+const password = process.env.SECRET_PASSWORD;
+const https = process.env.IS_HTTPS || false;
 
 require('../')({
     port: process.env.PORT || 8080,
     datastore: new inMemoryDatastore({
         filename: path.join(process.env.DATA_DIR || process.cwd(), '/database.json')
-    })
+    }),
+    'screwdriver-plugin-login': {
+        https,
+        jwtPrivateKey,
+        oauthClientId,
+        oauthClientSecret,
+        password
+    }
 }, (err, server) => {
     if (err) {
         winston.error(err);

--- a/kubernetes/api_deployment.yaml
+++ b/kubernetes/api_deployment.yaml
@@ -24,11 +24,32 @@ spec:
         env:
           - name: DATA_DIR
             value: /opt/screwdriver/data
+          - name: SECRET_JWT_PRIVATE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: plugin-login-secrets
+                key: jwtprivatekey
+          - name: SECRET_OAUTH_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: plugin-login-secrets
+                key: oauthclientid
+          - name: SECRET_OAUTH_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: plugin-login-secrets
+                key: oauthclientsecret
+          - name: SECRET_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: plugin-login-secrets
+                key: password
+
       volumes:
       - name: apikey
         secret:
           secretName: default-token-sw0ar
       - name: screwdriver-imdb
         awsElasticBlockStore:
-          volumeID: vol-3ea656b7
+          volumeID: vol-99e81310
           fsType: ext4

--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -37,18 +37,19 @@ function registerDefaultPlugins(server, callback) {
  */
 function registerResourcePlugins(server, config, callback) {
     const plugins = [
+        'screwdriver-plugin-login',
         'screwdriver-plugin-builds',
         'screwdriver-plugin-jobs',
         'screwdriver-plugin-pipelines',
         'screwdriver-plugin-platforms'
-    /* eslint-disable global-require */
-    ].map((plugin) => require(plugin));
-    /* eslint-enable global-require */
+    ];
 
-    async.eachSeries(plugins, (plugin, next) => {
+    async.eachSeries(plugins, (pluginName, next) => {
         server.register({
-            register: plugin,
-            options: {
+            /* eslint-disable global-require */
+            register: require(pluginName),
+            /* eslint-enable global-require */
+            options: config[pluginName] || {
                 datastore: config.datastore
             }
         }, {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "screwdriver-datastore-imdb": "^1.0.0",
     "screwdriver-plugin-builds": "^1.0.1",
     "screwdriver-plugin-jobs": "^1.0.0",
+    "screwdriver-plugin-login": "^1.0.0",
     "screwdriver-plugin-pipelines": "^1.0.0",
     "screwdriver-plugin-platforms": "^1.0.0",
     "vision": "^4.1.0",

--- a/test/lib/registerPlugins.test.js
+++ b/test/lib/registerPlugins.test.js
@@ -14,6 +14,7 @@ describe('Register Unit Test Case', () => {
         '../plugins/swagger'
     ];
     const resourcePlugins = [
+        'screwdriver-plugin-login',
         'screwdriver-plugin-builds',
         'screwdriver-plugin-jobs',
         'screwdriver-plugin-pipelines',
@@ -94,6 +95,32 @@ describe('Register Unit Test Case', () => {
                         prefix: '/v3'
                     }
                 });
+            });
+
+            done();
+        });
+    });
+
+    it('registers data for plugin when specified in the config object', (done) => {
+        serverMock.register.callsArgAsync(2);
+
+        main(serverMock, {
+            datastore: config.datastore,
+            'screwdriver-plugin-login': {
+                foo: 'bar'
+            }
+        }, () => {
+            Assert.equal(serverMock.register.callCount, pluginLength);
+
+            Assert.calledWith(serverMock.register, {
+                register: mocks['screwdriver-plugin-login'],
+                options: {
+                    foo: 'bar'
+                }
+            }, {
+                routes: {
+                    prefix: '/v3'
+                }
             });
 
             done();


### PR DESCRIPTION
This PR adds in the screwdriver-plugin-login plugin for authorization

The login requires it's own config value so in order to pass that to the plugin this PR also makes it possible to override the config values passed to plugins being registered by specifying it directly in the interface

This PR also:
Changes the AWS volume mounted to a new one created (the old one had invalid data in the imdb)
Mounts secrets in a directory called /etc/secrets for use when starting up the server