### PR TITLE
Upgrade to Node.js v6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:4
+FROM node:6
 
 # Create our application direcory
 RUN mkdir -p /usr/src/app

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: node:4
+box: node:6
 
 build:
   steps:


### PR DESCRIPTION
This PR upgrades the build and the runtime container to Node.js v6. (#25)
It seems that there is no incompatible api use. I confirmed that all the tests were successful with Node.js v6.3.0. 