### PR TITLE
Allow Executor to be Configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Example overriding `local.yaml`:
 
 ```yaml
 executor:
+    plugin: k8s
     k8s:
         host: 127.0.0.1
         token: this-is-a-real-token

--- a/bin/server
+++ b/bin/server
@@ -10,14 +10,9 @@ const DatastorePlugin = require(`screwdriver-datastore-${datastoreConfig.plugin}
 const datastore = new DatastorePlugin(datastoreConfig[datastoreConfig.plugin]);
 
 // Setup Executor
-// @TODO Remove this hackery after this is resolved
-//  https://github.com/screwdriver-cd/executor-k8s/issues/20
-if (config.has('executor.k8s.host')) {
-    process.env.K8S_HOST = config.get('executor.k8s.host');
-}
-if (config.has('executor.k8s.token')) {
-    process.env.K8S_TOKEN = config.get('executor.k8s.token');
-}
+const executorConfig = config.get('executor');
+const ExecutorPlugin = require(`screwdriver-executor-${executorConfig.plugin}`);
+const executor = new ExecutorPlugin(executorConfig[executorConfig.plugin]);
 
 // Setup Login
 const loginConfig = config.get('login');
@@ -29,7 +24,11 @@ const port = httpdConfig.port;
 require('../')({
     port,
     datastore,
-    'screwdriver-plugin-login': loginConfig
+    'screwdriver-plugin-login': loginConfig,
+    'screwdriver-plugin-builds': {
+        datastore,
+        executor
+    }
 }, (err, server) => {
     if (err) {
         winston.error(err);

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "inert": "^3.2.1",
     "js-yaml": "^3.6.1",
     "screwdriver-datastore-imdb": "^1.0.0",
-    "screwdriver-plugin-builds": "^1.0.1",
+    "screwdriver-plugin-builds": "^2.0.0",
     "screwdriver-plugin-jobs": "^1.0.0",
     "screwdriver-plugin-login": "^1.0.0",
     "screwdriver-plugin-pipelines": "^1.0.0",


### PR DESCRIPTION
This PR brings in the new `screwdriver-plugin-builds` https://github.com/screwdriver-cd/plugin-builds/pull/29 which requires the Executor to be passed in

Updates the README to include the `plugin` field under executor which is required

Updates `bin/server` to read in the right config values